### PR TITLE
Resolution bug noms diplomes

### DIFF
--- a/diploma-generator/src/main/java/fr/pantheonsorbonne/miage/MiageDiplomaGenerator.java
+++ b/diploma-generator/src/main/java/fr/pantheonsorbonne/miage/MiageDiplomaGenerator.java
@@ -42,7 +42,7 @@ public class MiageDiplomaGenerator extends AbstractDiplomaGenerator {
 
 	@Override
 	protected Collection<DiplomaSnippet> getDiplomaSnippets() {
-		String studentName = this.student.getName() + " " + this.student.getTitle();
+		String studentName = this.student.getTitle() + " " + this.student.getName();
 		return Arrays.asList(new DateSnippet(this.date), new NameSnippet(studentName));
 	}
 

--- a/diploma-webapp/src/main/java/fr/pantheonsorbonne/miage/Main.java
+++ b/diploma-webapp/src/main/java/fr/pantheonsorbonne/miage/Main.java
@@ -66,7 +66,7 @@ public class Main {
 		Iterables.addAll(students, repo);
 
 		for (int i = 0; i < students.size(); i++) {
-			if (i == studentId) {
+			if (i == studentId - 1) {
 				return students.get(i);
 			}
 		}


### PR DESCRIPTION
Les utilisateurs qui veulent voir leur diplome reçoivent bien leur diplome avec leur titre et le nom dans le bon ordre